### PR TITLE
Fix id format

### DIFF
--- a/js/j.js
+++ b/js/j.js
@@ -9,7 +9,8 @@ const tc = (e,c,d) => {
 
   let titles = tags.map(t => {
     // Adding ID to the actual titles
-    t.id = t.textContent;
+    let idContent = t.textContent.replace(/ /g, "_") 
+    t.id = idContent;
 
     //	Creating Elements
     let title = d.createElement(t.nodeName);
@@ -17,9 +18,8 @@ const tc = (e,c,d) => {
 
     // Adding Content
     link.textContent = t.textContent;
-    link.href = `#${t.textContent}`;
-    console.log(link.src)
-
+    link.href = `#${idContent}`;
+    
     title.appendChild(link);
     nav.appendChild(title);
   });


### PR DESCRIPTION
Los id tienen mal formato.
Cuando haces una referencia en un id no lo puedes hacer de la siguiente manera: 
`<div id="tabla uno">...</div>`
 
Lo anterior sería incorrecto. Para evitar eso se han reemplazado los espacios por guión bajo: 
`<div id="tabla_uno">...</div>`